### PR TITLE
Fixed duke_female_bodpa_holder gender

### DIFF
--- a/common/flavorization/00_ctp_tibetan.txt
+++ b/common/flavorization/00_ctp_tibetan.txt
@@ -75,7 +75,7 @@ duke_male_bodpa_holder = {
 }
 duke_female_bodpa_holder = {
 	type = character
-	gender = male
+	gender = female
 	special = holder
 	tier = duchy
 	priority = 124


### PR DESCRIPTION
Female dukes of Bodpa culture were not using correct title ("Khri Dpon"). This is corrected by changing the gender of duke_female_bodpa_holder to female.